### PR TITLE
Update axe-webdriverjs, to also get newer version of axe-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "protractor-axe-html-report-plugin",
   "version": "0.0.1",
   "dependencies": {
-    "axe-core": "^2.0.5",
     "axe-webdriverjs": "^2.0.1",
     "handlebars": "4.0.11",
     "httpster": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "axe-core": "^2.0.5",
-    "axe-webdriverjs": "^0.2.0",
+    "axe-webdriverjs": "^2.0.1",
     "handlebars": "4.0.11",
     "httpster": "1.0.3",
     "lodash": "4.17.5",


### PR DESCRIPTION
I'd like to propose updating the axe-webdriverjs dependency to the latest version of 2.0.1. This will also pull in the latest version of axe-core which has a variety of new rules, features and fixes. I also removed the listed dependency on axe-core as it doesn't do anything - the report is generated with rules from the version of axe-core that axe-webdriverjs depends on.